### PR TITLE
More flexible and explicit configuration of common-node application

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -13,8 +13,8 @@ var remap = {
  *
  * @param main the module to run
  */
-var run = module.exports = function(main) {
-  var options = {}, argv = [];
+var run = module.exports = function(main, options) {
+  var options = options || {}, argv = [];
   process.argv.forEach(function(arg) {
     if (!arg.indexOf('-')) {
       options[arg.substr(1)] = true;
@@ -73,7 +73,9 @@ var run = module.exports = function(main) {
         if (module.app) {
           var httpserver = require('./httpserver');
           if (!httpserver.started) {
-            httpserver.main(module.app, argv[2], {cluster:argv[3]});
+            var port = options.port || argv[2];
+            var cluster = options.cluster || argv[3];
+            httpserver.main(module.app, port, {cluster:cluster});
           }
         }
       }
@@ -103,6 +105,14 @@ var run = module.exports = function(main) {
     });
   }
 };
+
+function extend(){
+  for(var i=1; i<arguments.length; i++)
+    for(var key in arguments[i])
+      if(arguments[i].hasOwnProperty(key))
+          arguments[0][key] = arguments[i][key];
+  return arguments[0];
+}
 
 if (require.main === module) {
   process.argv.shift(); // remove node, which is first arg

--- a/lib/run.js
+++ b/lib/run.js
@@ -14,7 +14,7 @@ var remap = {
  * @param main the module to run
  */
 var run = module.exports = function(main, options) {
-  var options = options || {}, argv = [];
+  options = options || {}, argv = [];
   process.argv.forEach(function(arg) {
     if (!arg.indexOf('-')) {
       options[arg.substr(1)] = true;
@@ -73,9 +73,11 @@ var run = module.exports = function(main, options) {
         if (module.app) {
           var httpserver = require('./httpserver');
           if (!httpserver.started) {
-            var port = options.port || argv[2];
-            var cluster = options.cluster || argv[3];
-            httpserver.main(module.app, port, {cluster:cluster});
+            httpserver.main(module.app, 
+              (options.port || argv[2]),
+              {
+                cluster: (options.cluster || argv[3])
+              });
           }
         }
       }
@@ -106,13 +108,6 @@ var run = module.exports = function(main, options) {
   }
 };
 
-function extend(){
-  for(var i=1; i<arguments.length; i++)
-    for(var key in arguments[i])
-      if(arguments[i].hasOwnProperty(key))
-          arguments[0][key] = arguments[i][key];
-  return arguments[0];
-}
 
 if (require.main === module) {
   process.argv.shift(); // remove node, which is first arg

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   },
   "homepage":"http://github.com/olegp/common-node/",
   "main":"./lib/all.js",
+  "scripts": {
+    "test": "node test/all.js"
+  },
   "bin":{
     "common-node":"./bin/common-node"
   },


### PR DESCRIPTION
This is first commit in this pull request, nothing important. 

The background. I would be happy to use both type of configuration: via command-line or via hash parameter. I use the code below in the commit to change port inside my environment where 8080 port is already taken with other application. 

To conitinue I have few questions: 
1. Could you provide a test for `run.js` which has as much command-line arguments as you can do specify? 
2. Could you please add jshint and/or jscs configuration files for Javascript styleguides. I use Atom right now, but almost every popular text editor / IDE can follow these guidelines and makes collaborate much easier.
3. Could you please add TravicCI or CodeShip integration, so every commit in my pull requests will be tested and linted and you will be able to review code faster and with a bit smaller chance of mistake.
